### PR TITLE
use sentence case for error and info logs

### DIFF
--- a/translations/ui-local-kb-admin/en.json
+++ b/translations/ui-local-kb-admin/en.json
@@ -1,8 +1,8 @@
 {
   "meta.title": "Local KB Admin",
 
-  "errorLog": "Error Log",
-  "infoLog": "Info Log",
+  "errorLog": "Error log",
+  "infoLog": "Info log",
   "infoLogNo": "No information notices for this job.",
   "errorLogNo": "No errors to report.",
 


### PR DESCRIPTION
Use sentence case in translations as a part of this comment https://github.com/folio-org/ui-local-kb-admin/commit/22952d0dc36313f76923654d97e1cec3c40a00ed#r34483727