### PR TITLE
Adjust PaneWidth for settings pane

### DIFF
--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -25,6 +25,7 @@ export default class LocalKbAdminSettings extends React.Component {
     return (
       <Settings
         {...this.props}
+        navPaneWidth="20%"
         paneTitle={<FormattedMessage id="ui-local-kb-admin.meta.title" />}
         sections={this.sections}
       />


### PR DESCRIPTION
Assign navPaneWidth of 20% to the mid column of the settings pane. 