### PR TITLE
Virtualized info and error log lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-local-kb-admin
 
+## 1.2.0 IN PROGRESS
+* Improved performance when viewing info and error logs.
+
 ## 1.1.1 2019-09-10
 * Added translations.
 

--- a/src/components/views/ErrorLogs.js
+++ b/src/components/views/ErrorLogs.js
@@ -29,13 +29,12 @@ export default class ErrorLogs extends React.Component {
           recordNumber: <FormattedMessage id="ui-local-kb-admin.columns.recordNumber" />,
           message: <FormattedMessage id="ui-local-kb-admin.columns.errorLogMessage" />,
         }}
-        columnWidths={{
-          recordNumber: '10%',
-          message: '90%',
-        }}
         contentData={errorLog}
         formatter={{ recordNumber: ({ recordNumber }) => (recordNumber !== undefined ? recordNumber : '-') }}
         id="list-errorLog"
+        interactive={false}
+        maxHeight={800}
+        virtualize
         visibleColumns={['recordNumber', 'message']}
       />
     );

--- a/src/components/views/InfoLogs.js
+++ b/src/components/views/InfoLogs.js
@@ -29,13 +29,12 @@ export default class InfoLogs extends React.Component {
           recordNumber: <FormattedMessage id="ui-local-kb-admin.columns.recordNumber" />,
           message: <FormattedMessage id="ui-local-kb-admin.columns.infoLogMessage" />,
         }}
-        columnWidths={{
-          recordNumber: '10%',
-          message: '90%',
-        }}
         contentData={infoLog}
         formatter={{ recordNumber: ({ recordNumber }) => (recordNumber !== undefined ? recordNumber : '-') }}
         id="list-infoLog"
+        interactive={false}
+        maxHeight={800}
+        virtualize
         visibleColumns={['recordNumber', 'message']}
       />
     );


### PR DESCRIPTION
By default, MCL will just render the entire contents of a list. These info and error logs have 4000 and 8000 entries in our harvests from GoKB, which means that viewing them slows the entire browser down.

We can prevent MCL from rendering everything by turning on virtualization (`virtualize` and `maxHeight`).

I've also removed the `columnWidths` now that MCL can appropriately calculate them, and turned off `interactive` since nothing happens when you click the rows.