### PR TITLE
ERM-636: Use Spinner and FormattedUTCDate from Stripes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-local-kb-admin
 
+## 1.3.0 IN PROGRESS
+* Switched to using `<FormattedUTCDate>` from Stripes. ERM-635
+* Switched to using `<Spinner>` from Stripes. ERM-635
+
 ## 1.2.0 2019-12-02
 * Update stripes to v2.10.1 to support PaneFooter.
 * Move the Save & close button and add a Cancel button to Pane footer. ERM-414

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^2.10.1",
+    "@folio/stripes": "^2.12.0",
     "@folio/stripes-cli": "^1.8.0",
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
@@ -49,7 +49,7 @@
     "react-router-dom": "^4.1.1"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.10.1",
+    "@folio/stripes": "^2.12.0",
     "react": "*",
     "react-dom": "*",
     "react-redux": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/local-kb-admin",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "ERM KB Administration for FOLIO with Stripes",
   "main": "src/index.js",
   "publishConfig": {

--- a/src/components/LogsList/LogsList.js
+++ b/src/components/LogsList/LogsList.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
-import { MultiColumnList } from '@folio/stripes/components';
-import { Spinner } from '@folio/stripes-erm-components';
+import { MultiColumnList, Spinner } from '@folio/stripes/components';
 
 export default class LogsList extends React.Component {
   static propTypes = {

--- a/src/components/views/JobInfo.js
+++ b/src/components/views/JobInfo.js
@@ -13,9 +13,9 @@ import {
   Layout,
   Pane,
   Row,
+  Spinner,
 } from '@folio/stripes/components';
 import { IfPermission, TitleManager } from '@folio/stripes/core';
-import { Spinner } from '@folio/stripes-erm-components';
 
 import Logs from '../Logs';
 import FormattedDateTime from '../FormattedDateTime';


### PR DESCRIPTION
Spinner and FormattedUTCDate were promoted to Stripes as of version 2.12.0 so we should switch to pulling them from there now.