### PR TITLE
Add UI validation to check the uniqueness of an external data source …

### DIFF
--- a/src/settings/components/ExternalDataSourcesConfig/ExternalDataSourcesEdit.js
+++ b/src/settings/components/ExternalDataSourcesConfig/ExternalDataSourcesEdit.js
@@ -27,7 +27,7 @@ export default class ExternalDataSourcesEdit extends React.Component {
     const { externalKbs } = allValues;
     const uniqueNameSources = externalKbs.filter(externalKb => externalKb.name.toLowerCase() === value.toLowerCase());
     if (uniqueNameSources.length > 1) {
-      return <FormattedMessage id="ui-local-kb-admin.settings.externalDataSources.nameExists" />
+      return <FormattedMessage id="ui-local-kb-admin.settings.externalDataSources.nameExists" />;
     }
 
     return undefined;

--- a/src/settings/components/ExternalDataSourcesConfig/ExternalDataSourcesEdit.js
+++ b/src/settings/components/ExternalDataSourcesConfig/ExternalDataSourcesEdit.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
 import { Button, Card, Checkbox, Col, Layout, Row, Select, TextArea, TextField } from '@folio/stripes/components';
+import { composeValidators, requiredValidator } from '@folio/stripes-erm-components';
 import { validateURLIsValid, required } from '../../../util/validators';
 
 export default class ExternalDataSourcesEdit extends React.Component {
@@ -20,6 +21,16 @@ export default class ExternalDataSourcesEdit extends React.Component {
     }),
     onCancel: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
+  }
+
+  validateUniqueName = (value, allValues) => {
+    const { externalKbs } = allValues;
+    const uniqueNameSources = externalKbs.filter(externalKb => externalKb.name.toLowerCase() === value.toLowerCase());
+    if (uniqueNameSources.length > 1) {
+      return <FormattedMessage id="ui-local-kb-admin.settings.externalDataSources.nameExists" />
+    }
+
+    return undefined;
   }
 
   render() {
@@ -70,7 +81,10 @@ export default class ExternalDataSourcesEdit extends React.Component {
               label={<FormattedMessage id="ui-local-kb-admin.settings.externalDataSources.name" />}
               name={`${name}.name`}
               required
-              validate={required}
+              validate={composeValidators(
+                requiredValidator,
+                this.validateUniqueName,
+              )}
             />
           </Col>
           <Col xs={4}>

--- a/translations/ui-local-kb-admin/en.json
+++ b/translations/ui-local-kb-admin/en.json
@@ -67,6 +67,7 @@
   "settings.externalDataSources.callout.save.error": "There was an error saving the external data source. {error}",
   "settings.externalDataSources.callout.delete.success": "External data source successfully deleted.",
   "settings.externalDataSources.callout.delete.error": "There was an error deleting the external data source.{error}",
+  "settings.externalDataSources.nameExists": "This name already exists",
 
   "yes": "Yes",
   "no": "No",


### PR DESCRIPTION
…name, refs ERM-437

Added UI validation check to display an error when external data source name is not unique. 

The concurrent modification scenario is an edge case which needs to be handled across all the other erm modules and hence is ignored for now in this PR. Gill will be creating a JIRA for this.