### PR TITLE
Add route based code splitting to the local KB admin app

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import PropTypes from 'prop-types';
 import Switch from 'react-router-dom/Switch';
 import { Route } from '@folio/stripes/core';
-import Settings from './settings';
 
-import JobCreateRoute from './routes/JobCreateRoute';
-import JobsRoute from './routes/JobsRoute';
-import JobViewRoute from './routes/JobViewRoute';
+const JobCreateRoute = lazy(() => import('./routes/JobCreateRoute'));
+const JobsRoute = lazy(() => import('./routes/JobsRoute'));
+const JobViewRoute = lazy(() => import('./routes/JobViewRoute'));
+
+const Settings = lazy(() => import('./settings'));
 
 export default class App extends React.Component {
   static propTypes = {
@@ -18,16 +19,24 @@ export default class App extends React.Component {
     const { actAs, match: { path } } = this.props;
 
     if (actAs === 'settings') {
-      return <Settings {...this.props} />;
+      return (
+        <Suspense fallback={null}>
+          <Settings {...this.props} />
+        </Suspense>
+      );
     }
 
     return (
-      <Switch>
-        <Route path={`${path}/create`} component={JobCreateRoute} />
-        <Route path={`${path}/:id?`} component={JobsRoute}>
-          <Route path={`${path}/:id`} component={JobViewRoute} />
-        </Route>
-      </Switch>
+      <Suspense fallback={null}>
+        <Switch>
+          <Route path={`${path}/create`} component={JobCreateRoute} />
+          <Route path={`${path}/:id?`} component={JobsRoute}>
+            <Suspense fallback={null}>
+              <Route path={`${path}/:id`} component={JobViewRoute} />
+            </Suspense>
+          </Route>
+        </Switch>
+      </Suspense>
     );
   }
 }


### PR DESCRIPTION
Lazy load top level routing components in local KB admin app, similar to what we have done in agreements https://github.com/folio-org/ui-agreements/pull/416