### PR TITLE
ERM-727 and ERM-733: Added callouts and confirmation modals to ui-local-kb-admin

### DIFF
--- a/src/routes/JobCreateRoute.js
+++ b/src/routes/JobCreateRoute.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import compose from 'compose-function';
 import PropTypes from 'prop-types';
-import { stripesConnect } from '@folio/stripes/core';
+
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
+import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 import withFileHandlers from './components/withFileHandlers';
 import View from '../components/views/JobForm';
 
@@ -45,6 +47,8 @@ class JobCreateRoute extends React.Component {
     }).isRequired,
   };
 
+  static contextType = CalloutContext;
+
   static defaultProps = {
     handlers: {},
   }
@@ -60,7 +64,10 @@ class JobCreateRoute extends React.Component {
       .POST(job)
       .then(response => {
         const jobId = response?.id ?? '';
+        const jobClass = response?.class ?? '';
+        const name = response?.name ?? '';
         history.push(`/local-kb-admin/${jobId}${location.search}`);
+        this.context.sendCallout({ message: <SafeHTMLMessage id={`ui-local-kb-admin.job.created.success.${jobClass}`} values={{ name }} /> });
       });
   }
 

--- a/src/routes/JobViewRoute.js
+++ b/src/routes/JobViewRoute.js
@@ -52,7 +52,7 @@ class JobViewRoute extends React.Component {
         this.props.history.replace(
           {
             pathname: '/local-kb-admin',
-            search: `${this.props.location.search}`,
+            search: this.props.location.search,
           }
         );
         this.context.sendCallout({ message: <SafeHTMLMessage id={`ui-local-kb-admin.job.deleted.success.${jobClass}`} values={{ name }} /> });
@@ -87,19 +87,19 @@ class JobViewRoute extends React.Component {
           data={{
             job
           }}
+          isLoading={resources?.job?.isPending ?? true}
           onClose={this.handleClose}
           onDelete={this.showDeleteConfirmationModal}
-          isLoading={resources?.job?.isPending ?? true}
         />
         {this.state.showConfirmDelete && (
           <ConfirmationModal
-            id="delete-job-confirmation"
+            buttonStyle="danger"
             confirmLabel={<FormattedMessage id="ui-local-kb-admin.job.delete.confirmLabel" />}
             heading={<FormattedMessage id={deleteHeadingId} />}
+            id="delete-job-confirmation"
             message={<SafeHTMLMessage id={deleteMessageId} values={{ name }} />}
             onCancel={this.hideDeleteConfirmationModal}
             onConfirm={this.handleDelete}
-            buttonStyle="danger"
             open
           />
         )}

--- a/src/routes/JobViewRoute.js
+++ b/src/routes/JobViewRoute.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { stripesConnect } from '@folio/stripes/core';
 import { FormattedMessage } from 'react-intl';
+
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
+import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 import { ConfirmationModal } from '@folio/stripes/components';
+
 import JobInfo from '../components/views/JobInfo';
 
 class JobViewRoute extends React.Component {
@@ -35,26 +37,26 @@ class JobViewRoute extends React.Component {
     }).isRequired,
   };
 
-  constructor(props) {
-    super(props);
-    this.state = { showConfirmDelete: false };
-  }
+  static contextType = CalloutContext;
+
+  state = { showConfirmDelete: false };
 
   handleDelete = () => {
     const { resources } = this.props;
     const job = resources?.job?.records?.[0] ?? {};
     const name = job?.name ?? '';
     const jobClass = job?.class ?? '';
-    const id = job?.id ?? '';
     this.props.mutator.job
       .DELETE(job)
-      .then(() => this.props.history.replace(
-        {
-          pathname: '/local-kb-admin',
-          search: `${this.props.location.search}`,
-          state: { deletedJobId: id, deletedJobName: name, deletedJobClass: jobClass }
-        }
-      ));
+      .then(() => {
+        this.props.history.replace(
+          {
+            pathname: '/local-kb-admin',
+            search: `${this.props.location.search}`,
+          }
+        );
+        this.context.sendCallout({ message: <SafeHTMLMessage id={`ui-local-kb-admin.job.deleted.success.${jobClass}`} values={{ name }} /> });
+      });
   };
 
   handleClose = () => {

--- a/src/routes/JobsRoute.js
+++ b/src/routes/JobsRoute.js
@@ -1,12 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
-import { Callout } from '@folio/stripes/components';
 import { getSASParams } from '@folio/stripes-erm-components';
 import { StripesConnectedSource } from '@folio/stripes/smart-components';
 import { stripesConnect } from '@folio/stripes/core';
 import View from '../components/views/Jobs';
-import makeToast from './components/makeToast';
 
 const INITIAL_RESULT_COUNT = 100;
 const RESULT_COUNT_INCREMENT = 100;
@@ -71,7 +68,6 @@ class JobsRoute extends React.Component {
 
     this.logger = props.stripes.logger;
     this.searchField = React.createRef();
-    this.callout = React.createRef();
   }
 
   componentDidMount() {
@@ -97,14 +93,6 @@ class JobsRoute extends React.Component {
         const record = newRecords[0];
         history.push(`/local-kb-admin/${record.id}${location.search}`);
       }
-    }
-
-    const prevDeletedJobId = get(prevProps, 'location.state.deletedJobId', '');
-    const currentDeletedJobId = get(this.props, 'location.state.deletedJobId', '');
-    if (prevDeletedJobId !== currentDeletedJobId) {
-      const name = get(this.props, 'location.state.deletedJobName', '');
-      const jobClass = get(this.props, 'location.state.deletedJobClass', '');
-      if (name !== '') this.callout.current.sendCallout(makeToast('ui-local-kb-admin.job.deleted.success', jobClass, 'success', { name }));
     }
   }
 
@@ -133,23 +121,20 @@ class JobsRoute extends React.Component {
     }
 
     return (
-      <>
-        <View
-          data={{
-            jobs: resources?.jobs?.records ?? [],
-            resultValues: resources?.resultValues?.records ?? [],
-            statusValues: resources?.statusValues?.records ?? [],
-          }}
-          selectedRecordId={match.params.id}
-          queryGetter={this.queryGetter}
-          querySetter={this.querySetter}
-          searchString={location.search}
-          source={this.source}
-        >
-          {children}
-        </View>
-        <Callout ref={this.callout} />
-      </>
+      <View
+        data={{
+          jobs: resources?.jobs?.records ?? [],
+          resultValues: resources?.resultValues?.records ?? [],
+          statusValues: resources?.statusValues?.records ?? [],
+        }}
+        selectedRecordId={match.params.id}
+        queryGetter={this.queryGetter}
+        querySetter={this.querySetter}
+        searchString={location.search}
+        source={this.source}
+      >
+        {children}
+      </View>
     );
   }
 }

--- a/src/routes/JobsRoute.js
+++ b/src/routes/JobsRoute.js
@@ -127,9 +127,9 @@ class JobsRoute extends React.Component {
           resultValues: resources?.resultValues?.records ?? [],
           statusValues: resources?.statusValues?.records ?? [],
         }}
-        selectedRecordId={match.params.id}
         queryGetter={this.queryGetter}
         querySetter={this.querySetter}
+        selectedRecordId={match.params.id}
         searchString={location.search}
         source={this.source}
       >

--- a/src/settings/components/ExternalDataSourcesConfig/ExternalDataSourcesFields.js
+++ b/src/settings/components/ExternalDataSourcesConfig/ExternalDataSourcesFields.js
@@ -72,14 +72,14 @@ export default class ExternalDataSourcesFields extends React.Component {
     const custPropName = this.props?.input?.value?.name;
     return (
       <>
-      <ExternalDataSourceComponent
-        {...this.props}
-        onCancel={this.handleCancel}
-        onDelete={this.showDeleteConfirmationModal}
-        onSave={this.handleSave}
-        onEdit={this.handleEdit}
-      />
-      {this.state.showConfirmDelete && (
+        <ExternalDataSourceComponent
+          {...this.props}
+          onCancel={this.handleCancel}
+          onDelete={this.showDeleteConfirmationModal}
+          onSave={this.handleSave}
+          onEdit={this.handleEdit}
+        />
+        {this.state.showConfirmDelete && (
           <ConfirmationModal
             id="delete-external-data-source-confirmation"
             data-test-confirmationModal

--- a/src/settings/components/ExternalDataSourcesConfig/ExternalDataSourcesFields.js
+++ b/src/settings/components/ExternalDataSourcesConfig/ExternalDataSourcesFields.js
@@ -81,17 +81,17 @@ export default class ExternalDataSourcesFields extends React.Component {
         />
         {this.state.showConfirmDelete && (
           <ConfirmationModal
-            id="delete-external-data-source-confirmation"
-            data-test-confirmationModal
+            buttonStyle="danger"
             confirmLabel={<FormattedMessage id="ui-local-kb-admin.settings.externalDataSources.delete.confirmLabel" />}
+            data-test-confirmationModal
             heading={<FormattedMessage id="ui-local-kb-admin.settings.externalDataSources.delete.confirmHeading" />}
+            id="delete-external-data-source-confirmation"
             message={<SafeHTMLMessage id="ui-local-kb-admin.settings.externalDataSources.delete.confirmMessage" values={{ name: custPropName }} />}
             onCancel={this.hideDeleteConfirmationModal}
             onConfirm={() => {
               this.props.onDelete();
               this.hideDeleteConfirmationModal();
             }}
-            buttonStyle="danger"
             open
           />
         )}

--- a/src/settings/components/ExternalDataSourcesConfig/ExternalDataSourcesFields.js
+++ b/src/settings/components/ExternalDataSourcesConfig/ExternalDataSourcesFields.js
@@ -1,5 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
+import { FormattedMessage } from 'react-intl';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
+
+import { ConfirmationModal } from '@folio/stripes/components';
 import ExternalDataSourcesEdit from './ExternalDataSourcesEdit';
 import ExternalDataSourcesView from './ExternalDataSourcesView';
 
@@ -58,16 +63,39 @@ export default class ExternalDataSourcesFields extends React.Component {
       .then(() => this.setState({ editing: false }));
   }
 
+  showDeleteConfirmationModal = () => this.setState({ showConfirmDelete: true });
+
+  hideDeleteConfirmationModal = () => this.setState({ showConfirmDelete: false });
+
   render() {
     const ExternalDataSourceComponent = this.state.editing ? ExternalDataSourcesEdit : ExternalDataSourcesView;
+    const custPropName = this.props?.input?.value?.name;
     return (
+      <>
       <ExternalDataSourceComponent
         {...this.props}
         onCancel={this.handleCancel}
-        onDelete={this.props.onDelete}
+        onDelete={this.showDeleteConfirmationModal}
         onSave={this.handleSave}
         onEdit={this.handleEdit}
       />
+      {this.state.showConfirmDelete && (
+          <ConfirmationModal
+            id="delete-external-data-source-confirmation"
+            data-test-confirmationModal
+            confirmLabel={<FormattedMessage id="ui-local-kb-admin.settings.externalDataSources.delete.confirmLabel" />}
+            heading={<FormattedMessage id="ui-local-kb-admin.settings.externalDataSources.delete.confirmHeading" />}
+            message={<SafeHTMLMessage id="ui-local-kb-admin.settings.externalDataSources.delete.confirmMessage" values={{ name: custPropName }} />}
+            onCancel={this.hideDeleteConfirmationModal}
+            onConfirm={() => {
+              this.props.onDelete();
+              this.hideDeleteConfirmationModal();
+            }}
+            buttonStyle="danger"
+            open
+          />
+        )}
+      </>
     );
   }
 }

--- a/test/bigtest/interactors/external-data-sources.js
+++ b/test/bigtest/interactors/external-data-sources.js
@@ -9,6 +9,11 @@ import {
 } from '@bigtest/interactor';
 import KeyValueInteractor from '@folio/stripes-components/lib/KeyValue/tests/interactor'; // eslint-disable-line
 
+@interactor class ConfirmationModalInteractor {
+  isDeleteConfirmationButtonPresent = isPresent('[data-test-confirmation-modal-confirm-button]')
+  clickConfirmDeleteButton = clickable('[data-test-confirmation-modal-confirm-button]')
+}
+
 @interactor class ExternalDataSourceViewInteractor {
   isDeleteButtonPresent = isPresent('[data-test-external-data-source-delete]');
   isEditButtonPresent = isPresent('[data-test-external-data-source-edit]');
@@ -39,6 +44,8 @@ import KeyValueInteractor from '@folio/stripes-components/lib/KeyValue/tests/int
   fullPrefix = new KeyValueInteractor('[data-test-external-data-source-fullprefix]');
   principal = new KeyValueInteractor('[data-test-external-data-source-principal]');
   credentials = new KeyValueInteractor('[data-test-external-data-source-credentials]');
+
+  confirmation = new ConfirmationModalInteractor(['data-test-confirmationModal']);
 }
 
 @interactor class ExternalDataSourceEditInteractor {

--- a/test/bigtest/tests/settings-externalDataSources-test.js
+++ b/test/bigtest/tests/settings-externalDataSources-test.js
@@ -249,7 +249,7 @@ describe('External Data Source Settings', () => {
       this.visit('/settings/local-kb-admin/external-data-sources');
     });
 
-    describe('viewing the data sources', () => {
+    describe.only('viewing the data sources', () => {
       it('renders the list of external data sources', () => {
         expect(externaldatasources.isFormPresent).to.be.true;
       });
@@ -261,11 +261,24 @@ describe('External Data Source Settings', () => {
       describe('deleting 2 sources', () => {
         beforeEach(async function () {
           await externaldatasources.externalDataSourceList.items(0).clickDeleteButton();
-          await externaldatasources.externalDataSourceList.items(1).clickDeleteButton();
         });
 
-        it('reduces the count of data sources by 2', () => {
-          expect(externaldatasources.externalDataSourceList.size).to.equal(externalDataSourceCount - 2);
+        it('confirmation modal opens', () => {
+          expect(externaldatasources.externalDataSourceList.items(0).confirmation.isDeleteConfirmationButtonPresent).to.be.true;
+        });
+
+        describe('confirm delete', () => {
+          beforeEach(async () => {
+            await externaldatasources.externalDataSourceList.items(0).confirmation.clickConfirmDeleteButton();
+          });
+
+          it('reduces the count of data sources by 1', () => {
+            expect(externaldatasources.externalDataSourceList.size).to.equal(externalDataSourceCount - 1);
+          });
+          
+          it('reduces the count of data sources by 1', () => {
+            expect(externaldatasources.externalDataSourceList.size).to.equal(externalDataSourceCount - 1);
+          });
         });
       });
     });

--- a/test/bigtest/tests/settings-externalDataSources-test.js
+++ b/test/bigtest/tests/settings-externalDataSources-test.js
@@ -249,7 +249,7 @@ describe('External Data Source Settings', () => {
       this.visit('/settings/local-kb-admin/external-data-sources');
     });
 
-    describe.only('viewing the data sources', () => {
+    describe('viewing the data sources', () => {
       it('renders the list of external data sources', () => {
         expect(externaldatasources.isFormPresent).to.be.true;
       });
@@ -275,7 +275,7 @@ describe('External Data Source Settings', () => {
           it('reduces the count of data sources by 1', () => {
             expect(externaldatasources.externalDataSourceList.size).to.equal(externalDataSourceCount - 1);
           });
-          
+
           it('reduces the count of data sources by 1', () => {
             expect(externaldatasources.externalDataSourceList.size).to.equal(externalDataSourceCount - 1);
           });

--- a/translations/ui-local-kb-admin/en.json
+++ b/translations/ui-local-kb-admin/en.json
@@ -100,6 +100,11 @@
   "settings.externalDataSources.package": "Package",
   "settings.externalDataSources.principal": "Principal",
   "settings.externalDataSources.credentials": "Credentials",
+
+  "settings.externalDataSources.delete.confirmLabel": "Delete",
+  "settings.externalDataSources.delete.confirmHeading": "Delete external data source",
+  "settings.externalDataSources.delete.confirmMessage": "External data source <strong>{name}</strong> will be <strong>deleted</strong>.",
+
   "settings.externalDataSources.callout.save.success": "External data source successfully saved.",
   "settings.externalDataSources.callout.save.error": "There was an error saving the external data source. {error}",
   "settings.externalDataSources.callout.delete.success": "External data source successfully deleted.",


### PR DESCRIPTION
Callouts have been added upon creation of a job, and deletion callouts have been retooled to use the new stripes-core callout context. External data sources in settings now have a confirmation modal and tests have been updated