### PR TITLE
ERM-1896 upgrade react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-local-kb-admin
 
+## IN PROGRESS
+
+* Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. ERM-1896
+
 ## 5.0.0 2021-10-07
 * Upgrade to Stripes v7
 * Add `Export Log` option to the UI

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sinon": "^7.3.2"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.1.0",
     "@folio/stripes-erm-components": "^6.0.0",
     "compose-function": "^3.0.3",
     "final-form": "^4.18.5",


### PR DESCRIPTION
Upgrade `@folio/react-intl-safe-html` for compatibility with
`@folio/stripes` `v7` (react 17, react-intl 5).

Refs [ERM-1896](https://issues.folio.org/browse/ERM-1896), [STRIPES-769](https://issues.folio.org/browse/STRIPES-769)