### PR TITLE
chore: eslint-config-stripes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@babel/plugin-transform-runtime": "^7.12.1",
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
-    "@folio/eslint-config-stripes": "^5.2.0",
+    "@folio/eslint-config-stripes": "^6.0.0",
     "@folio/stripes": "^7.0.0",
     "@folio/stripes-cli": "^2.3.0",
     "@formatjs/cli": "^4.2.31",


### PR DESCRIPTION
Bumped dependency on eslint-config-stripes to 6.0.0

ERM-1971