### PR TITLE
ERM-2570: New button/settings don't display for Proxy server settings

### DIFF
--- a/src/settings/routes/ProxyServerSettingsRoute.js
+++ b/src/settings/routes/ProxyServerSettingsRoute.js
@@ -130,8 +130,6 @@ const ProxyServerSettingsRoute = () => {
       });
   };
 
-  if (!stringTemplates?.length) return <div />;
-
   return (
     <ProxyServerSettingsForm
       initialValues={getInitialValues()}


### PR DESCRIPTION
fix: Remove line which renders div if no string templates are present

ERM-2570