### PR TITLE
ERM-3613: Stripes v10 dependencies update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/local-kb-admin",
-  "version": "8.2.0",
+  "version": "9.0.0",
   "description": "ERM KB Administration for FOLIO with Stripes",
   "main": "src/index.js",
   "publishConfig": {
@@ -19,13 +19,13 @@
   "devDependencies": {
     "@babel/core": "^7.18.9",
     "@babel/eslint-parser": "^7.15.0",
-    "@folio/eslint-config-stripes": "^7.1.0",
-    "@folio/jest-config-stripes": "^2.0.0",
-    "@folio/stripes": "^9.2.0",
-    "@folio/stripes-cli": "^3.2.0",
-    "@folio/stripes-erm-components": "^9.2.0",
-    "@folio/stripes-erm-testing": "^2.2.1",
-    "@formatjs/cli": "^6.1.3",
+    "@folio/eslint-config-stripes": "^8.0.0",
+    "@folio/jest-config-stripes": "^3.0.0",
+    "@folio/stripes": "^10.0.0",
+    "@folio/stripes-cli": "^4.0.0",
+    "@folio/stripes-erm-components": "^10.0.0",
+    "@folio/stripes-erm-testing": "^3.0.0",
+    "@formatjs/cli": "^6.6.0",
     "dom-helpers": "^5.2.1",
     "eslint": "^7.32.0",
     "graphql": "^16.0.0",
@@ -34,7 +34,7 @@
     "prop-types-extra": ">=1.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-query": "^3.6.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
@@ -43,7 +43,7 @@
     "rxjs": "^6.6.3"
   },
   "dependencies": {
-    "@k-int/stripes-kint-components": "^5.8.3",
+    "@k-int/stripes-kint-components": "^5.11.0",
     "@rehooks/local-storage": "^2.4.5",
     "compose-function": "^3.0.3",
     "final-form": "^4.18.5",
@@ -55,11 +55,11 @@
     "react-final-form-arrays": "^3.1.1"
   },
   "peerDependencies": {
-    "@folio/stripes": "^9.2.0",
-    "@folio/stripes-erm-components": "^9.2.0",
+    "@folio/stripes": "^10.0.0",
+    "@folio/stripes-erm-components": "^10.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-query": "^3.9.0",
     "react-router-dom": "^5.2.0"
   },

--- a/src/routes/JobsRoute/JobsRoute.test.js
+++ b/src/routes/JobsRoute/JobsRoute.test.js
@@ -1,4 +1,4 @@
-
+import { cleanup } from '@folio/jest-config-stripes/testing-library/react';
 import { renderWithIntl } from '@folio/stripes-erm-testing';
 import { MemoryRouter } from 'react-router-dom';
 import translationsProperties from '../../../test/helpers/translationsProperties';
@@ -39,6 +39,9 @@ describe('JobsRoute', () => {
 
     describe('re-rendering the route', () => { // makes sure that we hit the componentDidUpdate block
       beforeEach(() => {
+        // Using this to clean up the render component prior to rerender
+        cleanup();
+
         renderWithIntl(
           <MemoryRouter>
             <JobsRoute {...routeProps} />


### PR DESCRIPTION
BREAKING Updated all stripes-* dependencies for the stripes v10 upgrade along with react-intl and formatjs/cli

Bumped version to 9.0.0

ERM-3613